### PR TITLE
feat: Add GitHub Action for automatic Docker image builds

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,27 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        file: ./docker/Dockerfile
+        push: true
+        tags: ghcr.io/${{ github.repository }}:latest


### PR DESCRIPTION
This change adds a GitHub Actions workflow to automatically build and publish the Docker image to the GitHub Container Registry (GHCR) whenever changes are pushed to the main branch. This automates the image creation process, ensuring that the latest version of the application is always available as a container image.

Fixes #1

---
*PR created automatically by Jules for task [2304603620403651882](https://jules.google.com/task/2304603620403651882) started by @UcnacDx2*